### PR TITLE
Potential fix for code scanning alert no. 1: Regular expression injection

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   },
   "dependencies": {
     "@solidity-parser/parser": "^0.13.2",
-    "eth-saddle": "^0.1.25"
+    "eth-saddle": "^0.1.25",
+    "lodash": "^4.17.21"
   },
   "resolutions": {
     "scrypt.js": "https://registry.npmjs.org/@compound-finance/ethereumjs-wallet/-/ethereumjs-wallet-0.6.3.tgz",

--- a/tests/Scenario.js
+++ b/tests/Scenario.js
@@ -7,6 +7,7 @@ const {ConsolePrinter} = require('../scenario/.tsbuilt/Printer.js');
 
 const fs = require('fs');
 const path = require('path');
+const _ = require('lodash');
 
 const basePath = process.env.proj_root || path.join(process.cwd());
 const baseScenarioPath = path.join(basePath, 'spec', 'scenario');
@@ -62,8 +63,9 @@ function run(file) {
   const network = process.env['NETWORK'] || process.env['network'] || 'test';
 
   if (scenarioEnv) {
-    console.log(`running scenarios matching: /${scenarioEnv}/i`);
-    scenarioFilter = new RegExp(scenarioEnv, 'i');
+    const safeScenarioEnv = _.escapeRegExp(scenarioEnv);
+    console.log(`running scenarios matching: /${safeScenarioEnv}/i`);
+    scenarioFilter = new RegExp(safeScenarioEnv, 'i');
   }
 
   describe('ScenarioTest', () => {


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/compound-protocol/security/code-scanning/1](https://github.com/Dargon789/compound-protocol/security/code-scanning/1)

To fix the problem, we need to sanitize the `scenarioEnv` variable before using it to construct a regular expression. This can be done using the `_.escapeRegExp` function from the lodash library, which escapes special characters in the input string that have special meaning in regular expressions.

1. Install the lodash library if it is not already installed.
2. Import the lodash library in the file.
3. Use the `_.escapeRegExp` function to sanitize the `scenarioEnv` variable before constructing the regular expression.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Add input sanitization to prevent regular expression injection vulnerabilities.

Bug Fixes:
- Prevent regular expression injection in the scenario environment variable.

Enhancements:
- Add lodash as a new dependency.

Tests:
- Update tests to reflect the changes.